### PR TITLE
Fix Index Out-of-Bounds Compilation Error in `adder_tree.sv`

### DIFF
--- a/adder_tree.sv
+++ b/adder_tree.sv
@@ -53,16 +53,16 @@ generate
     if( stage == '0 ) begin
       // stege 0 is actually module inputs
       for( adder = 0; adder < ST_OUT_NUM; adder++ ) begin: inputs_gen
-
-        always_comb begin
-          if( adder < INPUTS_NUM ) begin
-            data[stage][adder][ST_WIDTH-1:0] <= idata[adder][ST_WIDTH-1:0];
-            data[stage][adder][ODATA_WIDTH-1:ST_WIDTH] <= '0;
-          end else begin
+        if( adder < INPUTS_NUM ) begin
+          always_comb begin
+              data[stage][adder][ST_WIDTH-1:0] <= idata[adder][ST_WIDTH-1:0];
+              data[stage][adder][ODATA_WIDTH-1:ST_WIDTH] <= '0;
+          end
+        end else begin
+          always_comb begin
             data[stage][adder][ODATA_WIDTH-1:0] <= '0;
           end
-        end // always_comb
-
+        end
       end // for
     end else begin
       // all other stages hold adders outputs


### PR DESCRIPTION
## Description

The current implementation of `adder_tree.sv` contains a potential ​​compile-time index out-of-bounds error​​ due to unsafe `always_comb` logic inside the `generate` block. When `INPUTS_NUM` is not a power of two (e.g., 125), the `generate` loop may attempt to access `idata[adder]` with `adder >= INPUTS_NUM` , even if the `else` branch is logically unreachable.
This violates SystemVerilog's requirement that ​​constant indices must be compile-time valid​​, regardless of runtime conditions.

## Current Problematic Code

```systemverilog
always_comb begin
    if (adder < INPUTS_NUM) begin
        data[stage][adder][ST_WIDTH-1:0] <= idata[adder][ST_WIDTH-1:0]; // May OOB if adder >= INPUTS_NUM
        data[stage][adder][ODATA_WIDTH-1:ST_WIDTH] <= '0;
    end else begin
        data[stage][adder][ODATA_WIDTH-1:0] <= '0;
    end
end
```

## Proposed Fix

```systemverilog
if (adder < INPUTS_NUM) begin
    always_comb begin
        data[stage][adder][ST_WIDTH-1:0] <= idata[adder][ST_WIDTH-1:0];
        // Safe: only generated if adder < INPUTS_NUM
        data[stage][adder][ODATA_WIDTH-1:ST_WIDTH] <= '0;
    end
end else begin
    always_comb begin
        data[stage][adder][ODATA_WIDTH-1:0] <= '0;
    end
end
```

## Impact

- ​​**No functional change​​**: The logic remains identical.
- ​**Compilation safety**​​: Eliminates "constant index out of bounds" errors.