### PR TITLE
Fix array index out-of-bounds risk in `comb_repeater.sv` by restructuring `generate` blocks

### DIFF
--- a/comb_repeater.sv
+++ b/comb_repeater.sv
@@ -42,17 +42,22 @@ module comb_repeater #( parameter
   generate
     for( i=0; i<LENGTH; i=i+1 ) begin
 
-      always_comb begin
-
-        if( i==(LENGTH-1) ) begin
+      if( i==(LENGTH-1) ) begin
+        always_comb begin
           s1[i][WIDTH-1:0] <= ~in[WIDTH-1:0];
-        end else begin
+        end
+      end else begin
+        always_comb begin
           s1[i][WIDTH-1:0] <= ~s2[i+1][WIDTH-1:0];
         end
+      end
 
-        if( i==0 ) begin
+      if( i==0 ) begin
+        always_comb begin
           out[WIDTH-1:0] <= ~s1[i][WIDTH-1:0];
-        end else begin
+        end
+      end else begin
+        always_comb begin
           s2[i][WIDTH-1:0] <= ~s1[i][WIDTH-1:0];
         end
       end


### PR DESCRIPTION
### Description

This PR fixes a ​​compile-time array index out-of-bounds risk​​ in `comb_repeater.sv` by moving conditionals ​​outside​​ `always_comb` blocks within the `generate` loop.

### Problem

The original code uses `always_comb` with internal `if-else` to select between `in` and `s2[i+1]` for `s1[i]`:

```systemverilog
always_comb begin
    if( i==(LENGTH-1) ) begin
        s1[i][WIDTH-1:0] <= ~in[WIDTH-1:0];  // Safe
    end else begin
        s1[i][WIDTH-1:0] <= ~s2[i+1][WIDTH-1:0];  // OOB risk if `i=LENGTH-1` (but prevented by if-else)
    end
end
```
While functionally correct (due to the `if-else` guard), this structure forces the compiler to ​​statically check​​ `s2[i+1]` even when `i==LENGTH-1`, which could theoretically trigger tool errors or synthesis issues.

### Fix​​

Restructure to ​​prune invalid paths at compile time​​ by moving conditionals into the `generate` block:

```systemverilog
if( i==(LENGTH-1) ) begin
    always_comb begin
        s1[i][WIDTH-1:0] <= ~in[WIDTH-1:0];  // Only generated for i=LENGTH-1
    end
end else begin
    always_comb begin
        s1[i][WIDTH-1:0] <= ~s2[i+1][WIDTH-1:0];  // Only generated for i<LENGTH-1
    end
end
```

### Impact

- ​​**No functional change**​​: Logic behavior is identical.
​- ​**Safer compilation**​​: Eliminates any tool-specific warnings about potential OOB accesses.
​​- **Better synthesis**​​: Tools will not see unused array indices (e.g., `s2[LENGTH]`).

### Additional Context

This follows the same pattern as the fix for `adder_tree.sv` (PR #4), where generate-level conditionals are safer than `always_comb`-internal branching.