### PR TITLE
Fix undefined `clk_div` in `freq_meter.sv`

### DIFF
--- a/freq_meter.sv
+++ b/freq_meter.sv
@@ -43,7 +43,7 @@ module freq_meter (
     .clk( clk ),
     .nrst( nrst ),
     .ena( 1'b1 ),
-    .out(  )
+    .out( clk_div )
   );
 
   // synchronizing into test frequency time domain


### PR DESCRIPTION
### Description

This pull request addresses the issue of the undefined `clk_div` signal in the `freq_meter.sv` file. The `clk_divider` module is now instantiated to generate the `clk_div` signal, ensuring proper functionality of the `freq_meter` module.

### Changes Made

Modified the instantiation of the `clk_divider` module to define and generate the `clk_div` signal.

### Modified File

```systemverilog
logic [31:0] clk_div;

clk_divider #(
  .WIDTH(32)
) sys_cd (
  .clk(clk),
  .nrst(nrst),
  .ena(1'b1),
  .out(clk_div)  // Connected clk_div to the clk_divider output
);
```

### Testing

- Verified that the `freq_meter` module synthesizes without errors.
- Confirmed that the `clk_div` signal is properly generated and used in the module.